### PR TITLE
Feature/allow non git dirs to work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+tests:
+	/usr/bin/vim -c 'Vader! test/*' 
+

--- a/README.md
+++ b/README.md
@@ -1,34 +1,36 @@
 # ticket.vim
 
-Creates and manges git branch specific session files.
+Vim session management system with a focus on git branches.
 
 ![](https://user-images.githubusercontent.com/16519378/185827909-3c80e95f-668b-4d6f-b113-86d9d805eef6.gif)
 
-## Function
+## Usage
 
-This allows one to open and save session files associated with specific git branches easily. This is particularly useful if you need to switch branch, but want to preserve your vim state in the branch you are currently within.
+### Within a Git Repo
 
-When in the `branch1` you can execute `:SaveSession`, switch to `branch2` do what you need to do here then switch back to `branch1` and execute `:OpenSession`. Your vim instance will look exactly the same as it was prior to switching to `branch2`.
+Executing `:SaveSession` will save a session associated with the current branch checked out within the repo.
 
-In this way, each branch can have its very own session that can be easily opened (`:OpenSession`) and saved/overwritten (`:SaveSession`).
+Executing `OpenSession` will open the session you saved that is associated with the current branch name.
 
-Let's say every development ticket you get results in a new branch. Having a session & note file ready for when you have to revisit the ticket at a later date, due to another higher priority ticket requiring attention or lengthy code review process, is very useful for regaining your train of thought.
+If you switch branch you can save/open a different session associated with the branch you just switched to without affecting other branch sessions.
 
-One can also have these session files automatically open and save.
+Markdown files for taking notes associated with the branch can be managed using `:SaveNote` and `:OpenNote`
 
-Branch specific note files can be created & managed using `:OpenNote` & `:SaveNote`. This is useful when fixing a bug in a certain branch and you wish to document your findings while troubleshooting.
+### Outside a Git Repo
+
+Saving and opening sessions will work and automatically name the session file `main.vim` in case the directory is ever initialised as a git repo.
 
 ## Commands
 
-- `:SaveSession` -- To create a branch session 
+- `:SaveSession` -- To create a session 
 
-- `:OpenSession` -- Open the session
+- `:OpenSession` -- Open a session
 
-- `:CleanupSessions` -- Remove sessions that do not have a local branch
+- `:CleanupSessions` -- Remove sessions that do not have a local branch (only works within git repositories)
 
-- `:SaveNote` -- Save notes about the branch
+- `:SaveNote` -- Save notes related to the session
 
-- `:OpenNote` -- Open branch note
+- `:OpenNote` -- Open note associated with the session
 
 - `:GrepNotes *` -- Search all notes for given arg
 
@@ -50,12 +52,26 @@ let g:auto_ticket = 1
 let g:ticket_black_list = ['master', 'other-branch']
 ```
 
+Define a default branch name that will used to name all non git repo session files (default: main):
+
+```vim
+let g:default_session_name = 'master'
+```
+
 ## Installation
 
-For vim-plug
+With [Vim-Plug](https://github.com/junegunn/vim-plug):
 
 ```vim
 Plug 'superDross/ticket.vim'
+```
+
+With [Packer.nvim](https://github.com/wbthomason/packer.nvim):
+
+```lua
+require('packer').startup(function(use)
+  use 'superDross/ticket.vim'
+end)
 ```
 
 ## File Storage
@@ -72,6 +88,6 @@ The session files are stored as below; git repository directory name with all br
 
 ## Limitations
 
-- The organisation and storage of the session files depends upon the repo & git branch pairing name being unique.
+- The organisation and storage of the branch based session files depends upon the repo & git branch pairing name being unique.
 
 - Only works within \*NIX based systems.

--- a/plugin/ticket.vim
+++ b/plugin/ticket.vim
@@ -1,4 +1,4 @@
-" ticket.vim - Ticket
+" ticket.vim - Session
 " Author:      David Ross <https://github.com/superDross/>
 
 
@@ -63,7 +63,7 @@ function! GetBranchName()
 endfunction
 
 
-function! GetTicketDirPath()
+function! GetSessionDirPath()
   let name = CheckIfGitRepo() == 1 ? GetRepoName() : system('basename $(pwd) | tr -d "\n"')
   let dirpath = '~/.tickets/' . name
   call system('mkdir -p ' . dirpath)
@@ -80,40 +80,40 @@ function! BranchInBlackList()
 endfunction
 
 
-function! GetTicketFilePath(extension)
+function! GetSessionFilePath(extension)
   let branchname = CheckIfGitRepo() == 1 ? GetBranchName() : g:default_session_name
-  let dirpath = GetTicketDirPath()
+  let dirpath = GetSessionDirPath()
   return dirpath . '/' . branchname . a:extension
 endfunction
 
 
-function! GetTicketFilePathOnlyIfExists(extension)
-  let filepath = GetTicketFilePath(a:extension)
+function! GetSessionFilePathOnlyIfExists(extension)
+  let filepath = GetSessionFilePath(a:extension)
   call CheckFileExists(filepath)
   return filepath
 endfunction
 
 
 function! CreateSession()
-  let sessionfile = GetTicketFilePath('.vim')
+  let sessionfile = GetSessionFilePath('.vim')
   execute 'mksession! ' . sessionfile
 endfunction
 
 
 function! OpenSession()
-  let sessionfile = GetTicketFilePathOnlyIfExists('.vim')
+  let sessionfile = GetSessionFilePathOnlyIfExists('.vim')
   execute 'source ' . sessionfile
 endfunction
 
 
 function! CreateNote()
-  let mdfile = GetTicketFilePath('.md')
+  let mdfile = GetSessionFilePath('.md')
   execute 'w ' . mdfile
 endfunction
 
 
 function! OpenNote()
-  let mdfile = GetTicketFilePath('.md')
+  let mdfile = GetSessionFilePath('.md')
   execute 'e ' . mdfile
 endfunction
 
@@ -204,7 +204,7 @@ endfunction
 augroup ticket
   " automatically open and save sessions
   if DetermineAuto()
-    let session_file_path = GetTicketFilePath('.vim')
+    let session_file_path = GetSessionFilePath('.vim')
     if filereadable(expand(session_file_path))
       autocmd VimEnter * :if argc() ==# 0 | call OpenSession() | endif
     else

--- a/test/tests.vader
+++ b/test/tests.vader
@@ -1,6 +1,8 @@
 Before:
   call system('touch ~/test.file')
   call system('touch ~/.tickets/ticket.vim/old-session.vim')
+  call system('mkdir -p /tmp/temp')
+  call system('mkdir -p /tmp/temp2')
 
 After:
   let g:auto_ticket = 0
@@ -37,19 +39,22 @@ Execute(expect CheckFileExists pass):
 
 Execute(expect CheckIfGitRepo fail):
   :cd /
-  AssertThrows
-    \ CheckIfGitRepo()
+  AssertEqual
+    \ CheckIfGitRepo(),
+    \ 0
+Then(go back to original dir):
   :cd -
 
 Execute(expect CheckIfGitRepo pass):
   AssertEqual
     \ CheckIfGitRepo(),
-    \ 0
+    \ 1
 
 Execute(expect GetRepoName fail):
   :cd /
   AssertThrows
     \ GetRepoName()
+Then(go back to original dir):
   :cd -
 
 Execute(expect GetRepoName pass):
@@ -63,9 +68,11 @@ Execute(expect GitDirPath pass):
     \ '~/.tickets/ticket.vim'
 
 Execute(expect GitDirPath fail):
-  :cd /
-  AssertThrows
-    \ GetTicketDirPath()
+  :cd /tmp/temp
+  AssertEqual
+    \ GetTicketDirPath(),
+    \ '~/.tickets/temp'
+Then(go back to original dir):
   :cd -
 
 Execute(expect GetTicketFilePath session pass):
@@ -94,6 +101,37 @@ Execute(expect CreateSession pass):
     \ filereadable(
     \   expand('~/.tickets/ticket.vim/' . GetBranchName() . '.vim')
     \ )
+
+Execute(expect CreateSession non git based session to pass):
+  :cd /tmp/temp
+  call CreateSession()
+  Assert
+    \ filereadable(
+    \   expand('~/.tickets/temp/main.vim')
+    \ )
+Then(go back to original dir):
+  :cd -
+
+Execute(expect CreateSession different default session name works):
+  :cd /tmp/temp2
+  let g:default_session_name = 'different'
+  call CreateSession()
+  Assert
+    \ filereadable(
+    \   expand('~/.tickets/temp2/different.vim')
+    \ )
+Then(go back to original dir):
+  let g:default_session_name = 'main'
+  :cd -
+
+Execute(expect GetTicketFilePathOnlyIfExists pass when in non git repo):
+  :cd /tmp/temp
+  call CreateSession()
+  AssertEqual
+    \ GetTicketFilePathOnlyIfExists('.vim'),
+    \ '~/.tickets/temp/main.vim'
+Then(go back to original dir):
+  :cd -
 
 Execute(expect CreateNote pass):
   call CreateNote()
@@ -157,6 +195,13 @@ Execute(expect DeleteOldSessions remove old-session.vim):
   AssertEqual
     \ GetAllSessionNames('ticket.vim'),
     \ []
+
+Execute(expect DeleteOldSessions to fail in a non git repo):
+  :cd /tmp/temp
+  AssertThrows
+    \ DeleteOldSession(1)
+Then(go back to original dir):
+  :cd -
 
 " TODO: does not work during travis ci but does locally
 " I suspect it has something to do with the changing dirs, perhaps

--- a/test/tests.vader
+++ b/test/tests.vader
@@ -64,36 +64,36 @@ Execute(expect GetRepoName pass):
 
 Execute(expect GitDirPath pass):
   AssertEqual
-    \ GetTicketDirPath(),
+    \ GetSessionDirPath(),
     \ '~/.tickets/ticket.vim'
 
 Execute(expect GitDirPath fail):
   :cd /tmp/temp
   AssertEqual
-    \ GetTicketDirPath(),
+    \ GetSessionDirPath(),
     \ '~/.tickets/temp'
 Then(go back to original dir):
   :cd -
 
-Execute(expect GetTicketFilePath session pass):
+Execute(expect GetSessionFilePath session pass):
   AssertEqual
-    \ GetTicketFilePath('.vim'),
+    \ GetSessionFilePath('.vim'),
     \ '~/.tickets/ticket.vim/' . GetBranchName() . '.vim'
 
-Execute(expect GetTicketFilePath markdown pass):
+Execute(expect GetSessionFilePath markdown pass):
   AssertEqual
-    \ GetTicketFilePath('.md'),
+    \ GetSessionFilePath('.md'),
     \ '~/.tickets/ticket.vim/' . GetBranchName() . '.md'
 
-Execute(expect GetTicketFilePathOnlyIfExists pass):
+Execute(expect GetSessionFilePathOnlyIfExists pass):
   call CreateSession()
   AssertEqual
-    \ GetTicketFilePathOnlyIfExists('.vim'),
+    \ GetSessionFilePathOnlyIfExists('.vim'),
     \ '~/.tickets/ticket.vim/' . GetBranchName() . '.vim'
 
-Execute(expect GetTicketFilePathOnlyIfExists fail):
+Execute(expect GetSessionFilePathOnlyIfExists fail):
   AssertThrows
-    \ GetTicketFilePathOnlyIfExists('.py')
+    \ GetSessionFilePathOnlyIfExists('.py')
 
 Execute(expect CreateSession pass):
   call CreateSession()
@@ -124,11 +124,11 @@ Then(go back to original dir):
   let g:default_session_name = 'main'
   :cd -
 
-Execute(expect GetTicketFilePathOnlyIfExists pass when in non git repo):
+Execute(expect GetSessionFilePathOnlyIfExists pass when in non git repo):
   :cd /tmp/temp
   call CreateSession()
   AssertEqual
-    \ GetTicketFilePathOnlyIfExists('.vim'),
+    \ GetSessionFilePathOnlyIfExists('.vim'),
     \ '~/.tickets/temp/main.vim'
 Then(go back to original dir):
   :cd -


### PR DESCRIPTION
Intends to address https://github.com/superDross/ticket.vim/issues/10

- allows usage with non git repos
- cleans up some function names
- ensures all functions have descriptive comments