### PR TITLE
Do not ask to delete files if none have been found suitable for deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 tests:
+	rm ~/.tickets/ticket.vim/*
 	/usr/bin/vim -c 'Vader! test/*' 
 

--- a/plugin/ticket.vim
+++ b/plugin/ticket.vim
@@ -197,6 +197,11 @@ function DeleteOldSessions(force_input)
     endif
   endfor
 
+  if deletelist ==# []
+    echo "No sessions found to remove"
+    return
+  endif
+
   echo join(deletelist, "\r")
   if a:force_input == 1
     let answer = 'y'


### PR DESCRIPTION
Ensure we only ask to delete session files if suitable deletion candidates have been found