### PR TITLE
Use autoload directory and function naming conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 tests:
-	@rm ~/.tickets/ticket.vim/*
+	@rm -f ~/.tickets/ticket.vim/*
 	@/usr/bin/vim -c 'Vader! test/*' 
 

--- a/autoload/ticket/auto.vim
+++ b/autoload/ticket/auto.vim
@@ -3,11 +3,13 @@
 " Functions associated with automatically open and saving sessions
 
 
-function! _ShouldAuto(action)
+function! ticket#auto#ShouldAuto(action)
   " determine whether we should automatically open or save a session
   let action_dict = {'open': g:auto_ticket_open, 'save': g:auto_ticket_save}
   if g:auto_ticket || action_dict[a:action]
-    if BranchInBlackList() || IfBufferGitOperation() || !CanUseAutoInThisDir()
+    if ticket#blacklist#BranchInBlackList() || 
+    \  ticket#git#IfBufferGitOperation() ||
+    \  !ticket#auto#CanUseAutoInThisDir()
       return 0
     endif
   return 1
@@ -15,32 +17,33 @@ function! _ShouldAuto(action)
 endfunction
 
 
-function! ShouldAutoOpen()
+function! ticket#auto#ShouldAutoOpen()
   " determine if we should automically open a session
-  return _ShouldAuto('open')
+  return ticket#auto#ShouldAuto('open')
 endfunction
 
 
-function! ShouldAutoSave()
+function! ticket#auto#ShouldAutoSave()
   " determine if we should automically save a session
-  return _ShouldAuto('save')
+  return ticket#auto#ShouldAuto('save')
 endfunction
 
 
-function! AutoOpenSession()
+function! ticket#auto#AutoOpenSession()
   " opens session only if no files arguments have been parsed to vim at the
   " command line then force redraw to remove any visual artifacts.
   if argc() ==# 0
-    call OpenSession()
+    call ticket#sessions#OpenSession()
     redraw!
   endif
 endfunction
 
 
-function! CanUseAutoInThisDir()
+function! ticket#auto#CanUseAutoInThisDir()
   " determine if auto open/save functionality should open only in the current
   " directory if it is a git repo
-  if g:auto_ticket_git_only && CheckIfGitRepo()  || !g:auto_ticket_git_only
+  let is_git_repo = ticket#git#CheckIfGitRepo()
+  if g:auto_ticket_git_only && is_git_repo || !g:auto_ticket_git_only
     return 1
   endif
   return 0

--- a/autoload/ticket/blacklist.vim
+++ b/autoload/ticket/blacklist.vim
@@ -3,11 +3,11 @@
 " Functions associated with the black list feature
 
 
-function! BranchInBlackList()
+function! ticket#blacklist#BranchInBlackList()
   " determines if the branch name in the working directory is within the user
   " defined black list
-  let branchname = GetBranchName()
-  if (index(g:ticket_black_list, branchname) >= 0)
+  let branchname = ticket#git#GetBranchName()
+  if index(g:ticket_black_list, branchname) >= 0
     return 1
   endif
   return 0

--- a/autoload/ticket/deletion.vim
+++ b/autoload/ticket/deletion.vim
@@ -3,7 +3,7 @@
 " Module dealing with deletion of session files
 
 
-function DeleteFiles(files)
+function ticket#deletion#DeleteFiles(files)
   " delete all files in a given list
   for file in a:files
     call system('rm ' . file)
@@ -11,14 +11,14 @@ function DeleteFiles(files)
 endfunction
 
 
-function DeleteOldSessions(force_input)
+function ticket#deletion#DeleteOldSessions(force_input)
   " removes sessions files that no longer have local branches
   " only works within directories that are git repositories
-  if CheckIfGitRepo() == 0
+  if ticket#git#CheckIfGitRepo() == 0
       throw 'Sessions can only be deleted within a git repository.'
   endif
 	
-  let deletelist = GetSessionsWithoutBranches()
+  let deletelist = ticket#files#GetSessionsWithoutBranches()
 
   if deletelist ==# []
     echo "No sessions found to remove"
@@ -30,7 +30,7 @@ function DeleteOldSessions(force_input)
   let answer = a:force_input == 1 ? "y" : input(question)
 
   if answer ==# 'y'
-    call DeleteFiles(deletelist)
+    call ticket#deletion#DeleteFiles(deletelist)
   endif
 
 endfunction

--- a/autoload/ticket/git.vim
+++ b/autoload/ticket/git.vim
@@ -2,14 +2,14 @@
 "
 " All git command line interactions are stored here
 
-function! CheckIfGitRepo()
+function! ticket#git#CheckIfGitRepo()
   " returns 1 if working directory is a git repository, otherwise returns 0
   let msg = system('git rev-parse --is-inside-work-tree')
   return matchstr(msg, '.*not a git repository.*') ==# msg ? 0 : 1
 endfunction
 
 
-function! GetRepoName()
+function! ticket#git#GetRepoName()
   " returns remote name if set, otherwise top directory name is returned
   if system('git config --get remote.origin.url') !=# ''
     return system('basename -s .git `git config --get remote.origin.url` | tr -d "\n"')
@@ -19,13 +19,13 @@ function! GetRepoName()
 endfunction
 
 
-function! GetBranchName()
+function! ticket#git#GetBranchName()
   " returns the branch name checked out in the current working directory
   return system('git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"')
 endfunction
 
 
-function! GetAllBranchNames()
+function! ticket#git#GetAllBranchNames()
   " returns a list of all branch names (stripped of feature/bugfix prefix)
   " associated within the current repo
   return split(
@@ -36,7 +36,7 @@ function! GetAllBranchNames()
 endfunction
 
 
-function! IfBufferGitOperation()
+function! ticket#git#IfBufferGitOperation()
   " determines if current buffer is a git commit or rebase type
   let buftype = fnamemodify(bufname("%"), ":t")
   if buftype ==# 'COMMIT_EDITMSG' || buftype ==# 'git-rebase-todo'

--- a/autoload/ticket/notes.vim
+++ b/autoload/ticket/notes.vim
@@ -3,23 +3,23 @@
 " High level functions for creating, opening and getting notes
 
 
-function! CreateNote()
+function! ticket#notes#CreateNote()
   " creates or overwrites the note file associated with the git branch or
   " directory name in the working directory
-  let mdfile = GetSessionFilePath('.md')
+  let mdfile = ticket#files#GetSessionFilePath('.md')
   execute 'w ' . mdfile
 endfunction
 
 
-function! OpenNote()
+function! ticket#notes#OpenNote()
   " opens the note file associated with the git branch or directory name in
   " the working directory
-  let mdfile = GetSessionFilePath('.md')
+  let mdfile = ticket#files#GetSessionFilePath('.md')
   execute 'e ' . mdfile
 endfunction
 
 
-function! GrepNotes(query)
+function! ticket#notes#GrepNotes(query)
   " returns all notes file paths that contain the given query
   let ticketsdir = g:session_directory . '/**/*.md'
   execute 'vimgrep! /\c' . a:query . '/j ' . ticketsdir

--- a/autoload/ticket/sessions.vim
+++ b/autoload/ticket/sessions.vim
@@ -3,23 +3,23 @@
 " High level functions for creating, opening and getting sessions
 
 
-function! CreateSession()
+function! ticket#sessions#CreateSession()
   " creates or overwrites the session file associated with the git branch or
   " directory name in the working directory
-  let sessionfile = GetSessionFilePath('.vim')
+  let sessionfile = ticket#files#GetSessionFilePath('.vim')
   execute 'mksession! ' . sessionfile
 endfunction
 
 
-function! OpenSession()
+function! ticket#sessions#OpenSession()
   " opens the session file associated with the git branch or directory name in
   " the working directory
-  let sessionfile = GetSessionFilePathOnlyIfExists('.vim')
+  let sessionfile = ticket#files#GetSessionFilePathOnlyIfExists('.vim')
   execute 'source ' . sessionfile
 endfunction
 
 
-function! GetAllSessionNames(repo)
+function! ticket#sessions#GetAllSessionNames(repo)
   " returns all session names stripped of feature/bugfix prefix & extension
   " for a given repo
   return split(system(

--- a/plugin/ticket.vim
+++ b/plugin/ticket.vim
@@ -2,6 +2,13 @@
 " Author:      David Ross <https://github.com/superDross/>
 
 
+" prevents loading the plugin multiple times
+if exists('g:loaded_ticket')
+  finish
+endif
+let g:loaded_ticket = 1
+
+
 if !exists('g:auto_ticket')
   let g:auto_ticket = 0
 endif
@@ -35,32 +42,32 @@ endif
 if !exists('g:session_directory')
   " ~/.tickets should be hard coded within the function, it is not simply for
   " testing purposes
-  let g:session_directory = GetRootTicketDir('~/.tickets')
+  let g:session_directory = ticket#files#GetRootTicketDir('~/.tickets')
 endif
 
 
 augroup AutoTicket
   " automatically open and/or save sessions
-  if ShouldAutoOpen()
-    let session_file_path = GetSessionFilePath('.vim')
+  if ticket#auto#ShouldAutoOpen()
+    let session_file_path = ticket#files#GetSessionFilePath('.vim')
     if filereadable(expand(session_file_path))
       " ++nested is required as downstream operations trigger autocommands
-      autocmd VimEnter * ++nested :call AutoOpenSession()
+      autocmd VimEnter * ++nested :call ticket#auto#AutoOpenSession()
     endif
   endif
 
-  if ShouldAutoSave()
-    autocmd VimLeavePre,BufWritePost * ++nested :call CreateSession()
+  if ticket#auto#ShouldAutoSave()
+    autocmd VimLeavePre,BufWritePost * ++nested :call ticket#sessions#CreateSession()
   endif
 augroup END
 
 
-command! SaveSession :call CreateSession()
-command! OpenSession :call OpenSession()
-command! CleanupSessions :call DeleteOldSessions(0)
-command! SaveNote :call CreateNote()
-command! OpenNote :call OpenNote()
-command! -nargs=1 GrepNotes :call GrepNotes(<f-args>)
+command! SaveSession :call ticket#sessions#CreateSession()
+command! OpenSession :call ticket#sessions#OpenSession()
+command! CleanupSessions :call ticket#deletion#DeleteOldSessions(0)
+command! SaveNote :call ticket#notes#CreateNote()
+command! OpenNote :call ticket#notes#OpenNote()
+command! -nargs=1 GrepNotes :call ticket#notes#GrepNotes(<f-args>)
 command! -bang -nargs=* GrepTicketNotesFzf
   \ call fzf#vim#grep(
   \   'rg --type md --column --line-number --no-heading --color=always --smart-case -- '.shellescape(<q-args>), 1,

--- a/test/tests.vader
+++ b/test/tests.vader
@@ -16,12 +16,12 @@ After:
   call system('rm ~/test.file ~/.tickets/ticket.vim/*')
 
 
-Execute(expect GetBranchName pass):
+Execute(expect ticket#git#GetBranchName pass):
   let branchname = system(
     \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
     \ )
   AssertEqual
-    \ GetBranchName(),
+    \ ticket#git#GetBranchName(),
     \ branchname
 
 Execute(expect g:auto_ticket to autoset to zero):
@@ -34,83 +34,83 @@ Execute(expect g:ticket_black_list to autoset to empty list):
     \ g:ticket_black_list,
     \ []
 
-Execute(expect CheckFileExists fail):
+Execute(expect ticket#files#CheckFileExists fail):
   AssertThrows
-    \ CheckFileExists('/home/nonfile')
+    \ ticket#files#CheckFileExists('/home/nonfile')
 
-Execute(expect CheckFileExists pass):
+Execute(expect ticket#files#CheckFileExists pass):
   AssertEqual
-    \ CheckFileExists(expand('~') . '/test.file'),
+    \ ticket#files#CheckFileExists(expand('~') . '/test.file'),
     \ expand('~') . '/test.file'
 
-Execute(expect CheckIfGitRepo fail):
+Execute(expect ticket#git#CheckIfGitRepo fail):
   :cd /
   AssertEqual
-    \ CheckIfGitRepo(),
+    \ ticket#git#CheckIfGitRepo(),
     \ 0
 Then(go back to original dir):
   :cd -
 
-Execute(expect CheckIfGitRepo pass):
+Execute(expect ticket#git#CheckIfGitRepo pass):
   AssertEqual
-    \ CheckIfGitRepo(),
+    \ ticket#git#CheckIfGitRepo(),
     \ 1
 
-Execute(expect GetRepoName fail):
+Execute(expect ticket#git#GetRepoName fail):
   :cd /
   AssertThrows
-    \ GetRepoName()
+    \ ticket#git#GetRepoName()
 Then(go back to original dir):
   :cd -
 
-Execute(expect GetRepoName pass):
+Execute(expect ticket#git#GetRepoName pass):
   AssertEqual
-    \ GetRepoName(),
+    \ ticket#git#GetRepoName(),
     \ 'ticket.vim'
 
 Execute(expect GitDirPath pass):
   AssertEqual
-    \ GetSessionDirPath(),
+    \ ticket#files#GetSessionDirPath(),
     \ '~/.tickets/ticket.vim'
 
 Execute(expect GitDirPath fail):
   :cd /tmp/temp
   AssertEqual
-    \ GetSessionDirPath(),
+    \ ticket#files#GetSessionDirPath(),
     \ '~/.tickets/temp'
 Then(go back to original dir):
   :cd -
 
-Execute(expect GetSessionFilePath session pass):
+Execute(expect ticket#files#GetSessionFilePath session pass):
   AssertEqual
-    \ GetSessionFilePath('.vim'),
-    \ '~/.tickets/ticket.vim/' . GetBranchName() . '.vim'
+    \ ticket#files#GetSessionFilePath('.vim'),
+    \ '~/.tickets/ticket.vim/' . ticket#git#GetBranchName() . '.vim'
 
-Execute(expect GetSessionFilePath markdown pass):
+Execute(expect ticket#files#GetSessionFilePath markdown pass):
   AssertEqual
-    \ GetSessionFilePath('.md'),
-    \ '~/.tickets/ticket.vim/' . GetBranchName() . '.md'
+    \ ticket#files#GetSessionFilePath('.md'),
+    \ '~/.tickets/ticket.vim/' . ticket#git#GetBranchName() . '.md'
 
-Execute(expect GetSessionFilePathOnlyIfExists pass):
-  call CreateSession()
+Execute(expect ticket#files#GetSessionFilePathOnlyIfExists pass):
+  call ticket#sessions#CreateSession()
   AssertEqual
-    \ GetSessionFilePathOnlyIfExists('.vim'),
-    \ '~/.tickets/ticket.vim/' . GetBranchName() . '.vim'
+    \ ticket#files#GetSessionFilePathOnlyIfExists('.vim'),
+    \ '~/.tickets/ticket.vim/' . ticket#git#GetBranchName() . '.vim'
 
-Execute(expect GetSessionFilePathOnlyIfExists fail):
+Execute(expect ticket#files#GetSessionFilePathOnlyIfExists fail):
   AssertThrows
-    \ GetSessionFilePathOnlyIfExists('.py')
+    \ ticket#files#GetSessionFilePathOnlyIfExists('.py')
 
-Execute(expect CreateSession pass):
-  call CreateSession()
+Execute(expect ticket#sessions#CreateSession pass):
+  call ticket#sessions#CreateSession()
   Assert
     \ filereadable(
-    \   expand('~/.tickets/ticket.vim/' . GetBranchName() . '.vim')
+    \   expand('~/.tickets/ticket.vim/' . ticket#git#GetBranchName() . '.vim')
     \ )
 
-Execute(expect CreateSession non git based session to pass):
+Execute(expect ticket#sessions#CreateSession non git based session to pass):
   :cd /tmp/temp
-  call CreateSession()
+  call ticket#sessions#CreateSession()
   Assert
     \ filereadable(
     \   expand('~/.tickets/temp/main.vim')
@@ -118,10 +118,10 @@ Execute(expect CreateSession non git based session to pass):
 Then(go back to original dir):
   :cd -
 
-Execute(expect CreateSession different default session name works):
+Execute(expect ticket#sessions#CreateSession different default session name works):
   :cd /tmp/temp2
   let g:default_session_name = 'different'
-  call CreateSession()
+  call ticket#sessions#CreateSession()
   Assert
     \ filereadable(
     \   expand('~/.tickets/temp2/different.vim')
@@ -130,159 +130,159 @@ Then(go back to original dir):
   let g:default_session_name = 'main'
   :cd -
 
-Execute(expect GetSessionFilePathOnlyIfExists pass when in non git repo):
+Execute(expect ticket#files#GetSessionFilePathOnlyIfExists pass when in non git repo):
   :cd /tmp/temp
-  call CreateSession()
+  call ticket#sessions#CreateSession()
   AssertEqual
-    \ GetSessionFilePathOnlyIfExists('.vim'),
+    \ ticket#files#GetSessionFilePathOnlyIfExists('.vim'),
     \ '~/.tickets/temp/main.vim'
 Then(go back to original dir):
   :cd -
 
-Execute(expect CreateNote pass):
-  call CreateNote()
+Execute(expect ticket#notes#CreateNote pass):
+  call ticket#notes#CreateNote()
   Assert
     \ filereadable(
-    \   expand('~/.tickets/ticket.vim/' . GetBranchName() . '.md')
+    \   expand('~/.tickets/ticket.vim/' . ticket#git#GetBranchName() . '.md')
     \ )
 
-Execute(expect BranchInBlackList pass):
+Execute(expect ticket#blacklist#BranchInBlackList pass):
   let branchname = system(
     \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
     \ )
   let g:ticket_black_list = [branchname, 'other-branch']
   AssertEqual
-    \ BranchInBlackList(),
+    \ ticket#blacklist#BranchInBlackList(),
     \ 1
 
-Execute(expect BranchInBlackList fail):
+Execute(expect ticket#blacklist#BranchInBlackList fail):
   AssertEqual
-    \ BranchInBlackList(),
+    \ ticket#blacklist#BranchInBlackList(),
     \ 0
 
-Execute(expect GetAllSessionNames to show all sessions):
+Execute(expect ticket#sessions#GetAllSessionNames to show all sessions):
   AssertEqual
-    \ GetAllSessionNames('ticket.vim'),
+    \ ticket#sessions#GetAllSessionNames('ticket.vim'),
     \ ['old-session']
 
-Execute(expect DeleteOldSessions remove old-session.vim):
-  call DeleteOldSessions(1)
+Execute(expect ticket#deletion#DeleteOldSessions remove old-session.vim):
+  call ticket#deletion#DeleteOldSessions(1)
   AssertEqual
-    \ GetAllSessionNames('ticket.vim'),
+    \ ticket#sessions#GetAllSessionNames('ticket.vim'),
     \ []
 
-Execute(expect DeleteOldSessions to fail in a non git repo):
+Execute(expect ticket#deletion#DeleteOldSessions to fail in a non git repo):
   :cd /tmp/temp
   AssertThrows
-    \ DeleteOldSession(1)
+    \ ticket#deletion#DeleteOldSession(1)
 Then(go back to original dir):
   :cd -
 
-Execute(expect GetRootTicketDir to return XDG dir when set):
+Execute(expect ticket#files#GetRootTicketDir to return XDG dir when set):
   let $XDG_DATA_HOME = expand('~')
   AssertEqual
-    \ GetRootTicketDir('~/.tickets'),
+    \ ticket#files#GetRootTicketDir('~/.tickets'),
     \ expand('~') . '/tickets-vim'
 
-Execute(expect GetRootTicketDir to return legacy directory):
+Execute(expect ticket#files#GetRootTicketDir to return legacy directory):
   AssertEqual
-    \ GetRootTicketDir('~/.tickets'),
+    \ ticket#files#GetRootTicketDir('~/.tickets'),
     \ expand('~/.tickets')
 
-Execute(expect GetRootTicketDir to return local share directory):
+Execute(expect ticket#files#GetRootTicketDir to return local share directory):
   call system('mkdir -p ~/.local/share')
   AssertEqual
-  \ GetRootTicketDir('~/.dir_does_not_exist'),
+  \ ticket#files#GetRootTicketDir('~/.dir_does_not_exist'),
   \ expand('~/.local/share/tickets-vim')
 
-Execute(expect ShouldAutoSave should work with auto_ticket set):
+Execute(expect ticket#auto#ShouldAutoSave should work with auto_ticket set):
   let g:auto_ticket = 1
   AssertEqual
-    \ ShouldAutoSave(),
+    \ ticket#auto#ShouldAutoSave(),
     \ 1
 
-Execute(expect ShouldAutoSave should work with auto_open set):
+Execute(expect ticket#auto#ShouldAutoSave should work with auto_open set):
   let g:auto_ticket_save = 1
   AssertEqual
-    \ ShouldAutoSave(),
+    \ ticket#auto#ShouldAutoSave(),
     \ 1
 
-Execute(expect ShouldAutoSave should work with auto_git_only set):
+Execute(expect ticket#auto#ShouldAutoSave should work with auto_git_only set):
   let g:auto_ticket_save = 1
   let g:auto_ticket_git_only = 1
   AssertEqual
-    \ ShouldAutoSave(),
+    \ ticket#auto#ShouldAutoSave(),
     \ 1
 
-Execute(expect ShouldAutoSave should not work in current branch if black listed):
+Execute(expect ticket#auto#ShouldAutoSave should not work in current branch if black listed):
   let g:auto_ticket_save = 1
   let branchname = system(
     \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
     \ )
   let g:ticket_black_list = [branchname]
   AssertEqual
-    \ ShouldAutoSave(),
+    \ ticket#auto#ShouldAutoSave(),
     \ 0
 
-Execute(expect ShouldAutoSave should work if outside black listed branhces):
+Execute(expect ticket#auto#ShouldAutoSave should work if outside black listed branhces):
   let g:auto_ticket_save = 1
   let g:ticket_black_list = ['something']
   AssertEqual
-    \ ShouldAutoSave(),
+    \ ticket#auto#ShouldAutoSave(),
     \ 1
 
-Execute(expect ShouldAutoSave should not work with auto_git_only set when in root dir):
+Execute(expect ticket#auto#ShouldAutoSave should not work with auto_git_only set when in root dir):
   :cd /
   let g:auto_ticket_save = 1
   let g:auto_ticket_git_only = 1
   AssertEqual
-    \ ShouldAutoSave(),
+    \ ticket#auto#ShouldAutoSave(),
     \ 0
 Then(go back to original dir):
   :cd - 
 
-Execute(expect ShouldAutoOpen should work with auto_ticket set):
+Execute(expect ticket#auto#ShouldAutoOpen should work with auto_ticket set):
   let g:auto_ticket = 1
   AssertEqual
-    \ ShouldAutoOpen(),
+    \ ticket#auto#ShouldAutoOpen(),
     \ 1
 
-Execute(expect ShouldAutoOpen should work with auto_open set):
+Execute(expect ticket#auto#ShouldAutoOpen should work with auto_open set):
   let g:auto_ticket_open = 1
   AssertEqual
-    \ ShouldAutoOpen(),
+    \ ticket#auto#ShouldAutoOpen(),
     \ 1
 
-Execute(expect ShouldAutoOpen should work with auto_git_only set):
+Execute(expect ticket#auto#ShouldAutoOpen should work with auto_git_only set):
   let g:auto_ticket_open = 1
   let g:auto_ticket_git_only = 1
   AssertEqual
-    \ ShouldAutoOpen(),
+    \ ticket#auto#ShouldAutoOpen(),
     \ 1
 
-Execute(expect ShouldAutoOpen should not work in current branch if black listed):
+Execute(expect ticket#auto#ShouldAutoOpen should not work in current branch if black listed):
   let g:auto_ticket_open = 1
   let branchname = system(
     \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
     \ )
   let g:ticket_black_list = [branchname]
   AssertEqual
-    \ ShouldAutoOpen(),
+    \ ticket#auto#ShouldAutoOpen(),
     \ 0
 
-Execute(expect ShouldAutoOpen should work if outside black listed branhces):
+Execute(expect ticket#auto#ShouldAutoOpen should work if outside black listed branhces):
   let g:auto_ticket_open = 1
   let g:ticket_black_list = ['something']
   AssertEqual
-    \ ShouldAutoOpen(),
+    \ ticket#auto#ShouldAutoOpen(),
     \ 1
 
-Execute(expect ShouldAutoOpen should not work with auto_git_only set when in root dir):
+Execute(expect ticket#auto#ShouldAutoOpen should not work with auto_git_only set when in root dir):
   :cd /
   let g:auto_ticket_open = 1
   let g:auto_ticket_git_only = 1
   AssertEqual
-    \ ShouldAutoOpen(),
+    \ ticket#auto#ShouldAutoOpen(),
     \ 0
 Then(go back to original dir):
   :cd - 


### PR DESCRIPTION
Placing most of the logic within autoload/ should reduce start up time
of the application while also following vimscript plugin conventions
with naming and structure.

A new global variable is used to ensure we do not load the plugin
multiple times.