### PR TITLE
Use $() in place of backticks for evaluations

### DIFF
--- a/autoload/ticket/git.vim
+++ b/autoload/ticket/git.vim
@@ -12,9 +12,9 @@ endfunction
 function! ticket#git#GetRepoName()
   " returns remote name if set, otherwise top directory name is returned
   if system('git config --get remote.origin.url') !=# ''
-    return system('basename -s .git `git config --get remote.origin.url` | tr -d "\n"')
+    return system('basename -s .git $(git config --get remote.origin.url) | tr -d "\n"')
   else
-    return system('basename `git rev-parse --show-toplevel` | tr -d "\n"')
+    return system('basename $(git rev-parse --show-toplevel) | tr -d "\n"')
   endif
 endfunction
 


### PR DESCRIPTION
Intends to fix: https://github.com/superDross/ticket.vim/issues/34