### PR TITLE
Fix globbing issues with fish shell

### DIFF
--- a/autoload/ticket/files.vim
+++ b/autoload/ticket/files.vim
@@ -73,7 +73,7 @@ function! ticket#files#GetSessionsWithoutBranches()
   for session in ticket#sessions#GetAllSessionNames(repo)
     if index(branches, session) == -1  " if session not in branches
       let sessionpath = system(
-      \  'find ' . g:session_directory . '/' . repo . ' -type f -name ' . '*' . session . '.vim'
+      \  'find ' . g:session_directory . '/' . repo . ' -type f -name ' . session . '.vim'
       \)
       call add(session_list, sessionpath)
     endif

--- a/autoload/ticket/sessions.vim
+++ b/autoload/ticket/sessions.vim
@@ -25,6 +25,6 @@ function! ticket#sessions#GetAllSessionNames(repo)
   return split(system(
   \  'find ' . g:session_directory . '/' . a:repo . ' -type f -name "*.vim" |
   \   xargs -I {} basename {} |
-  \   sed "s/.\{4\}$//"'
+  \   sed ' . '''s/.\{4\}$//'''
   \))
 endfunction


### PR DESCRIPTION
This PR fixes issues with file globbing in the fish shell. Namely the `$` in the sed command is interpreted as a variable when it's in double quotes. I also removed the`*` session file name glob as it throws errors in fish shell and seemed unnecessary.