### PR TITLE
FindSessions has a source mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Saving and opening sessions will work and automatically name the session file `m
 
 - `:ForceCleanupSessions` -- Same as `CleanupSession` but forcefully removes without prompting user (only works within git repositories)
 
-- `:FindSessions *` -- Search all session files name for a given arg and open the quickfix menu
+- `:FindSessions *` -- Search all session files name for a given arg and open the quickfix menu (sourcing the sessions under the cursor can be performed by pressing `O`)
 
 - `:TicketSessionsFzf` -- Use fzf to search and open sessions (requires [fzf.vim](https://github.com/junegunn/fzf.vim) or [fzf-lua](https://github.com/ibhagwan/fzf-lua))
 

--- a/autoload/ticket/sessions.vim
+++ b/autoload/ticket/sessions.vim
@@ -31,11 +31,10 @@ endfunction
 
 function! ticket#sessions#FindSessions(query) abort
   " returns all notes file paths that contain the given query
-  " TODO: find away to create a custom mapping for quickfix
-  "       https://vi.stackexchange.com/questions/21254/visual-delete-items-from-quickfix-list
-  "       /after/ftplugin/qf.vim could work but applies to all
-  "       quickfix lists
-  let ticketsdir = g:session_directory . '/**/*.vim'
-  execute 'vimgrep! /\c' . a:query . '/j ' . ticketsdir
-  copen
+  execute 'vimgrep /\%^/j ' . g:session_directory . '/**/*.vim'
+  call ticket#utils#QuickFixFilter(a:query)
+  " conceal file contents
+  syntax match ConcealedDetails /\v\|.*/ conceal
+  setlocal conceallevel=2
+  setlocal concealcursor=nvic
 endfunction

--- a/autoload/ticket/utils.vim
+++ b/autoload/ticket/utils.vim
@@ -29,3 +29,15 @@ function! ticket#utils#DeprecatedCommand(old_command, new_command) abort
   echoerr 'DEPRECATED: ' . a:old_command . ' has been replaced with the ' . 
   \ a:new_command . ' command'
 endfunction
+
+
+function! ticket#utils#QuickFixFilter(query) abort
+  " opens & filters the quickfix results with a given query
+  copen
+  if a:query !=# ''
+    if !ticket#utils#IsInstalled('cfilter')
+      packadd cfilter
+    endif
+    execute 'Cfilter /' . a:query . '/'
+  endif
+endfunction

--- a/plugin/ticket.vim
+++ b/plugin/ticket.vim
@@ -67,6 +67,14 @@ augroup AutoTicket
 augroup END
 
 
+augroup QuickFixMappings
+  " tried <CR> but cannot get it to only apply when FindSessions is used
+  " instead we opt for `O` as a means of calling source on the given selection
+  autocmd filetype qf 
+    \ nnoremap <buffer> O :execute 'source ' . split(getline('.'), '\|')[0]<CR>
+augroup END
+
+
 command! SaveSession :call ticket#sessions#CreateSession()
 command! OpenSession :call ticket#sessions#OpenSession()
 command! DeleteSession :call ticket#deletion#DeleteSession()
@@ -81,7 +89,7 @@ if get(g:, 'ticket_use_fzf_default', 0)
   command! -bang -nargs=* FindSessions :call ticket#fzf#sessions#FzfSessions(<q-args>)
 else
   command! -nargs=1 GrepNotes :call ticket#notes#GrepNotes(<f-args>)
-  command! -nargs=1 FindSessions :call ticket#sessions#FindSessions(<f-args>)
+  command! -nargs=* FindSessions :call ticket#sessions#FindSessions(<q-args>)
 endif
 
 command! -bang -nargs=* TicketNotesFzf :call ticket#fzf#notes#FzfNotes(<q-args>)


### PR DESCRIPTION
`O` can be used to source the file under the cursor in the quickfix menu

Mapping <CR> means all quickfix menus results regardless of when opened will try to source the file under the cursor. This is unwanted and cant find a way to unmap the mapping after sourcing. Therefore I have opted for a `O` mapping that works across all quickfix menus.

fixes: https://github.com/superDross/ticket.vim/issues/47