### PR TITLE
Remove g:ticket_legacy_filename option and associated logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ For in vim docs, execute the following command:
 :help ticket.vim
 ```
 
-<!-- TODO: remove or modify this after increasing to the next major version -->
-
 > :warning: **Deprecation Warning**
 >
 > Session naming has changed; any branches containing `/` will have a different session
@@ -132,12 +130,6 @@ Ask for confirmation before overwriting existing session file, will not work if 
 
 ```vim
 let g:ticket_overwrite_confirm = 1
-```
-
-Use legacy session filenames system (see `:help ticket-deprecations` for more info):
-
-```vim
-let g:ticket_legacy_filename = 1
 ```
 
 ## Installation

--- a/autoload/ticket/git.vim
+++ b/autoload/ticket/git.vim
@@ -6,12 +6,6 @@
 function! s:NormaliseBranchName(full_branch_name) abort
   " remove/replace unwanted substrings from the given branchname
   " files cannot contain / in unix file systems, % must be escaped
-
-  " TODO: remove in the next major version
-  if g:ticket_legacy_filenames
-    return substitute(a:full_branch_name, '.*/\|\n', '', 'g')
-  endif
-
   let partial = substitute(a:full_branch_name, '\n', '', 'g')
   let partial = substitute(partial, '/', '%', 'g')
   return substitute(partial, '%', '\\%', 'g')

--- a/doc/ticket.txt
+++ b/doc/ticket.txt
@@ -34,7 +34,6 @@ Contents ~
    3. The |g:ticket_use_fzf_default| option
    4. The |g:ticket_very_verbose| option
    5. The |g:ticket_overwrite_confirm| option
-   6. The |g:ticket_legacy_filename| option
  6. Deprecations                                        |ticket-deprecations|
  7. Contact                                             |ticket-contact|
  8. License                                             |ticket-license|
@@ -360,20 +359,14 @@ if the autosave feature is enabled (default: 0):
   :let g:ticket_overwrite_confirm = 1
 <
 
---------------------------------------------------------------------------------
-The *g:ticket_legacy_filename* option
-
-Use legacy session filenames system (see `:help ticket-deprecations` for more info):
-
->
-  :let g:ticket_legacy_filename = 1
-<
-
 ================================================================================
                                                               *ticket-deprecations*
 Deprecations ~
 
-This current version has altered the way session names are saved.
+As of 2.0.0, the way sessions are named has been permanently changed.
+
+If you wish to use the old session naming system then you will have to
+pin ticket.vim to version 1.6.0 or the associated commit.
 
 Previously, any branch names containing a forward slash would be partially
 stripped. For example, a branch named `fix/this-bug` would be saved as
@@ -387,16 +380,6 @@ Going forward all forward slashes will be converted to `%`.
 
 To be clear, if a branch is named `fix/this-bug` it will be saved as a session
 file named `fix%this-bug.vim` from now on.
-
-If you want to continue to use the legacy naming system please set the following
-option in your vimrc:
-
->
-  :let g:ticket_legacy_filename = 1
-<
-
-This will be removed in version 2.0.0 and then the new session saving system will
-be set in place.
 
 To migrate your old sessions I recommend searching for your old sessions using
 `FindSessions` or `TicketSessionsFzf` and selecting your session of interest

--- a/plugin/ticket.vim
+++ b/plugin/ticket.vim
@@ -48,19 +48,6 @@ if !exists('g:ticket_overwrite_confirm')
   let g:ticket_overwrite_confirm = 0
 endif
 
-" TODO: remove in the next major version
-if !exists('g:ticket_legacy_filenames')
-  let g:ticket_legacy_filenames = 0
-else
-  augroup DeprecationWarning
-    autocmd VimEnter *
-      \ :echohl WarningMsg |
-      \ echo 'WARNING: g:ticket_legacy_filenames will be removed in the near future
-      \ (:help ticket-deprecations for more information).' |
-      \ echohl None
-  augroup END
-endif
-
 
 if !exists('g:session_directory')
   " ~/.tickets should be hard coded within the function, it is not simply for
@@ -112,6 +99,3 @@ endif
 
 command! -bang -nargs=* TicketNotesFzf :call ticket#fzf#notes#FzfNotes(<q-args>)
 command! -bang -nargs=* TicketSessionsFzf :call ticket#fzf#sessions#FzfSessions(<q-args>)
-
-" TODO: remove in the next major release
-command! -bang -nargs=* GrepTicketNotesFzf :call ticket#utils#DeprecatedCommand('GrepTicketNotesFzf', 'TicketNotesFzf')

--- a/test/ci-tests.vader
+++ b/test/ci-tests.vader
@@ -1,6 +1,4 @@
 Before:
-  " TODO: remove this before 2.0.0 release
-  let g:ticket_legacy_filenames = 0
   call system('touch ~/test.file')
   call system('mkdir -p /tmp/temp')
   call system('mkdir -p /tmp/temp2')
@@ -25,16 +23,6 @@ Execute(expect ticket#git#GetBranchName pass):
   AssertEqual
     \ ticket#git#GetBranchName(),
     \ branchname
-
-" TODO: remove this before 2.0.0 release
-Execute(expect ticket#git#GetBranchName use legacy branchname with ticket_legacy_filename):
-  let g:ticket_legacy_filenames = 1
-  let branchname = system(
-    \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
-    \ )
-   AssertEqual
-     \ ticket#git#GetBranchName(),
-     \ branchname
 
 Execute(expect g:auto_ticket to autoset to zero):
   AssertEqual
@@ -172,18 +160,6 @@ Execute(expect ticket#blacklist#BranchInBlackList pass):
     \ ticket#blacklist#BranchInBlackList(),
     \ 1
 
-" TODO: remove this before 2.0.0 release
-Execute(expect ticket#blacklist#BranchInBlackList pass):
-  let g:ticket_legacy_filenames = 1
-  let branchname = system(
-    \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
-    \ )
-  let g:ticket_black_list = [branchname, 'other-branch']
-  AssertEqual
-    \ ticket#blacklist#BranchInBlackList(),
-    \ 1
-
-
 Execute(expect ticket#blacklist#BranchInBlackList fail):
   AssertEqual
     \ ticket#blacklist#BranchInBlackList(),
@@ -261,18 +237,6 @@ Execute(expect ticket#auto#ShouldAutoSave should not work in current branch if b
     \ ticket#auto#ShouldAutoSave(),
     \ 0
 
-" TODO: remove this before 2.0.0 release
-Execute(expect ticket#auto#ShouldAutoSave should not work in current branch if black listed LEGACY):
-  let g:ticket_legacy_filenames = 1
-  let g:auto_ticket_save = 1
-  let branchname = system(
-    \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
-    \ )
-  let g:ticket_black_list = [branchname]
-  AssertEqual
-    \ ticket#auto#ShouldAutoSave(),
-    \ 0
-
 Execute(expect ticket#auto#ShouldAutoSave should work if outside black listed branhces):
   let g:auto_ticket_save = 1
   let g:ticket_black_list = ['something']
@@ -314,19 +278,6 @@ Execute(expect ticket#auto#ShouldAutoOpen should not work in current branch if b
   let branchname = substitute(system(
     \ 'git symbolic-ref --short HEAD | tr -d "\n"'
     \ ), '/', '\\%', 'g')
-  let g:ticket_black_list = [branchname]
-  AssertEqual
-    \ ticket#auto#ShouldAutoOpen(),
-    \ 0
-
-
-" TODO: remove this before 2.0.0 release
-Execute(expect ticket#auto#ShouldAutoOpen should not work in current branch if black listed LEGACY):
-  let g:ticket_legacy_filenames = 1
-  let g:auto_ticket_open = 1
-  let branchname = system(
-    \ 'git symbolic-ref --short HEAD | tr "/" "\n" | tail -n 1 | tr -d "\n"'
-    \ )
   let g:ticket_black_list = [branchname]
   AssertEqual
     \ ticket#auto#ShouldAutoOpen(),


### PR DESCRIPTION
With this, the user can no longer use the legacy session file naming system.